### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/KohithFS/ad83340f-ace6-4585-8bdc-4fa6d9a3bb91/0f4ab771-efc4-4c43-abbb-511b247032f0/_apis/work/boardbadge/912a54b8-c862-42c0-b378-9748b43976bd)](https://dev.azure.com/KohithFS/ad83340f-ace6-4585-8bdc-4fa6d9a3bb91/_boards/board/t/0f4ab771-efc4-4c43-abbb-511b247032f0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#531](https://dev.azure.com/KohithFS/ad83340f-ace6-4585-8bdc-4fa6d9a3bb91/_workitems/edit/531). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.